### PR TITLE
allowing dropdown to be sized properly

### DIFF
--- a/demo/dropdown.html
+++ b/demo/dropdown.html
@@ -20,7 +20,7 @@
 			margin: 40px 20px;
 		}
 		button {
-				font-size: 0.7rem;
+			font-size: 0.7rem;
 		}
 	</style>
 </head>
@@ -55,8 +55,8 @@
 		<div style="clear:both;"></div>
 
 		<div id="dropdown-container">
-			<d2l-dropdown id="dropdown" target-id="opener-default">
-				<div style="min-width: 10rem; margin: 1rem;">
+			<d2l-dropdown id="dropdown" target-id="opener-default" style="max-width: 10rem;">
+				<div style="margin: 1rem;">
 					<d2l-demo-content>
 						<p>Grumpy wizards make toxic brew for evil Queen and Jack.</p>
 						<a href="http://thumbs.dreamstime.com/x/angry-wizard-14480360.jpg">Grumpy Wizards</a>

--- a/dropdown.html
+++ b/dropdown.html
@@ -24,7 +24,7 @@
 				border-radius: 0.3rem;
 				box-shadow: 0 2px 12px 0 rgba(86, 90, 92, .2);
 				box-sizing: border-box;
-				position: absolute;
+				position: relative;
 			}
 			.d2l-dropdown-container:focus {
 				outline: none;
@@ -73,6 +73,10 @@
 				right: 30px;
 			}
 
+			.d2l-dropdown-content-container {
+				overflow: hidden;
+			}
+
 			@keyframes d2l-dropdown-animation {
 				0% { transform: translate(0,-10px); opacity: 0; }
 				100% { transform: translate(0,0); opacity: 1; }
@@ -93,7 +97,9 @@
 		</style>
 		<div class="d2l-dropdown-container" tabindex="0">
 			<div class="d2l-dropdown-pointer"></div>
-			<content></content>
+			<div class="d2l-dropdown-content-container">
+				<content></content>
+			</div>
 		</div>
 	</template>
 


### PR DESCRIPTION
@dbatiste

Couldn't just remove the absolute positioning, since the balloon tail was relying on it a little bit.

This change essentially makes this possible: `<d2l-dropdown style="min-width:200px; max-width:500px;">`, which is a pretty nice way to size it. If we want, we could even have a default max/min width... otherwise it'll take up as much room as the content needs.

Also needed to add that extra `div` so that content which exceeds the max-width (if set) get clipped somehow. Could set `overflow:hidden` on the other container because then it would clip the tail.