### PR TITLE
Changing to use setTimeout instead of async.

### DIFF
--- a/dropdown-behavior.html
+++ b/dropdown-behavior.html
@@ -38,7 +38,7 @@
 				return;
 			}
 
-			this.async(function() {
+			setTimeout(function() {
 				if (!this.opened || !document.activeElement) {
 					return;
 				}


### PR DESCRIPTION
@dlockhart : suggesting we change this to use setTimeout.

When Polymer's async method is used, the `document.activeElement` is the `body` at this point (the focus hasn't been moved to other elements in the dropdown) and so the dropdown closes.  When `setTimeout` is used `document.activeElement` is the element that is expected to have the focus (ex. a link in the dropdown).
