### PR TITLE
 Add "no-side-borders" menu attribute for menus.

### DIFF
--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -104,7 +104,8 @@
 					reflectToAttribute: true
 				},
 				noSideBorders: {
-					type: Boolean
+					type: Boolean,
+					reflectToAttribute: true
 				}
 			},
 

--- a/d2l-menu.html
+++ b/d2l-menu.html
@@ -32,6 +32,16 @@
 				border-bottom-right-radius: 0.3rem;
 				border-bottom-color: var(--d2l-color-titanius);
 			}
+			:host-context([no-side-borders]) .d2l-menu-items d2l-menu-item-return[role="menuitem"],
+			:host-context([no-side-borders]) .d2l-menu-items ::content > [role="menuitem"] {
+				border-left-color: transparent;
+				border-right-color: transparent;
+			}
+			:host-context([no-side-borders]) .d2l-menu-items d2l-menu-item-return[role="menuitem"],
+			:host-context([no-side-borders]) .d2l-menu-items ::content > .d2l-menu-item-first[role="menuitem"],
+			:host-context([no-side-borders]) .d2l-menu-items ::content > .d2l-menu-item-last[role="menuitem"] {
+				border-radius: 0;
+			}
 			.d2l-menu-items d2l-menu-item-return[role="menuitem"]:focus,
 			.d2l-menu-items d2l-menu-item-return[role="menuitem"]:hover,
 			.d2l-menu-items ::content > [role="menuitem"]:focus,
@@ -92,6 +102,9 @@
 					type: String,
 					observer: '_labelChanged',
 					reflectToAttribute: true
+				},
+				noSideBorders: {
+					type: Boolean
 				}
 			},
 

--- a/demo/menu.html
+++ b/demo/menu.html
@@ -22,7 +22,11 @@
 			<button onclick="addItem();">Add Top Item</button>
 			<button onclick="showDeepMenu();">Show Deep Menu</button>
 		</div>
-		<div style="margin-bottom: 0.75rem;"></div>
+		<div style="margin-bottom: 0.75rem;">
+			<label for="config-no-side-borders">
+				No Side Borders <input id="config-no-side-borders" type="checkbox" />
+			</label>
+		</div>
 	</div>
 
 	<div>
@@ -109,6 +113,15 @@
 			page_menu.addEventListener('select', function(e) {
 				console.log('item selected:', e);
 			});
+		});
+
+		var config_noSideBorders = document.getElementById('config-no-side-borders');
+		config_noSideBorders.addEventListener('change', function(e) {
+			if (e.target.checked) {
+				page_menu.setAttribute('no-side-borders', true);
+			} else {
+				page_menu.removeAttribute('no-side-borders');
+			}
 		});
 
 		function appendMenu() {


### PR DESCRIPTION
When rendering in a context that already provides border, it is desirable to not display side borders on menus/menu-items.  This `no-side-borders` attribute effectively makes the side borders transparent when item is not hovered/focused, and also removes the border radius.  As per design, the side borders are still displayed on hover/focus.

@dlockhart , @capajon : does this attribute make sense given nav context?  Or, do you think there is more that needs to change?