### PR TITLE
Dbatiste/enable template based menus

### DIFF
--- a/d2l-menu-item.html
+++ b/d2l-menu-item.html
@@ -40,8 +40,8 @@
 				window.D2L.PolymerBehaviors.MenuItemBehavior
 			],
 
-			ready: function() {
-				if (this.hasChildView) {
+			_initialize: function() {
+				if (this.hasChildView && !this.$$('iron-icon')) {
 					var icon = document.createElement('iron-icon');
 					Polymer.dom(icon).setAttribute('icon', 'd2l-tier1:chevron-right');
 					Polymer.dom(this.root).insertBefore(

--- a/demo/menu-custom-components.html
+++ b/demo/menu-custom-components.html
@@ -95,6 +95,13 @@
 		<d2l-menu label="Seven Summits" style="width: 400px;">
 			<template is="dom-repeat" items="{{menuItems}}">
 				<d2l-menu-item text="{{item.text}}">
+					<template is="dom-if" if="{{item.hasSubMenu}}">
+						<d2l-menu label="{{item.text}}">
+							<template is="dom-repeat" items="{{item.menuItems}}">
+								<d2l-menu-item text="{{item.text}}"></d2l-menu-item>
+							</template>
+						</d2l-menu>
+					</template>
 				</d2l-menu-item>
 			</template>
 		</d2l-menu>
@@ -107,12 +114,17 @@
 				menuItems: {
 					type: Object,
 					value: [
-						{text: 'Introduction', more: []},
-						{text: 'Searching the Heavens', more: []},
-						{text: 'The Solar System', more: []},
-						{text: 'Stars & Galaxies', more: []},
-						{text: 'The Night Sky', more: []},
-						{text: 'The Universe', more: []}
+						{text: 'Introduction'},
+						{text: 'Searching the Heavens'},
+						{text: 'The Solar System', hasSubMenu: true, menuItems: [
+							{text: 'Formation'},
+							{text: 'Modern Solar System'},
+							{text: 'Future Solar System'},
+							{text: 'The Planets'}
+						]},
+						{text: 'Stars & Galaxies'},
+						{text: 'The Night Sky'},
+						{text: 'The Universe'}
 					]
 				}
 			}

--- a/menu-item-behavior.html
+++ b/menu-item-behavior.html
@@ -13,8 +13,8 @@
 
 		listeners: {
 			'blur': '__onBlur',
-			'focus': '__onFocus',
 			'dom-change': '__onDomChange',
+			'focus': '__onFocus',
 			'hide-complete': '__onHideComplete',
 			'keydown': '__onKeyDown',
 			'mouseenter': '__onMouseEnter',
@@ -64,10 +64,6 @@
 			}
 		},
 
-		__onDomChange: function() {
-			this.__initialize();
-		},
-
 		__action: function() {
 
 			if (this.disabled) {
@@ -85,6 +81,10 @@
 
 		__onBlur: function() {
 			this.fire('_blur');
+		},
+
+		__onDomChange: function() {
+			this.__initialize();
 		},
 
 		__onFocus: function() {

--- a/menu-item-behavior.html
+++ b/menu-item-behavior.html
@@ -14,6 +14,7 @@
 		listeners: {
 			'blur': '__onBlur',
 			'focus': '__onFocus',
+			'dom-change': '__onDomChange',
 			'hide-complete': '__onHideComplete',
 			'keydown': '__onKeyDown',
 			'mouseenter': '__onMouseEnter',
@@ -45,13 +46,26 @@
 
 		ready: function() {
 			var children = this.getEffectiveChildren();
+			if (children && children.length > 0 && children[0].tagName !== 'TEMPLATE') {
+				this.__initialize();
+			}
+		},
+
+		__initialize: function() {
+			var children = this.getEffectiveChildren();
 			if (children && children.length > 0) {
 				this.hasChildView = true;
 				this.__children = children;
 				this.setAttribute('aria-haspopup', true);
-				// assumption: single, focusable child view
 				this.__children[0].setAttribute('label', this.text);
+				if (this._initialize) {
+					this._initialize();
+				}
 			}
+		},
+
+		__onDomChange: function() {
+			this.__initialize();
 		},
 
 		__action: function() {


### PR DESCRIPTION
This change is to support template-based menus, including nested menus.  See demo-component included with this change for example.  

It relies on the `template`'s `dom-change` event which signals when the template is stamped out in order to initialize the items.  Non-template based menus are still supported.