### PR TITLE
If root view not displayed then clone to get dimensions.

### DIFF
--- a/hierarchical-view-behavior.html
+++ b/hierarchical-view-behavior.html
@@ -14,6 +14,12 @@
 				-webkit-transition: height 300ms linear;
 				transition: height 300ms linear;
 			}
+			:host([clone]) {
+				display: inline-block;
+				position: absolute;
+				left: -10000px;
+			}
+
 			:host([child-view]),
 			:host ::content [child-view] {
 				display: none;
@@ -137,16 +143,37 @@
 		},
 
 		__autoSize: function(view) {
-			if (this.childView) {
+
+			if (this.childView || this.getAttribute('clone')) {
 				return;
 			}
-			var rect;
-			if (view === this) {
-				rect = this.$$('.d2l-hierarchical-view-content').getBoundingClientRect();
+
+			/* clone to get height only if not displayed */
+			if (this.offsetHeight) {
+
+				var rect;
+				if (view === this) {
+					rect = this.$$('.d2l-hierarchical-view-content').getBoundingClientRect();
+				} else {
+					rect = view.getBoundingClientRect();
+				}
+				this.style.height = rect.height + 'px';
+
 			} else {
-				rect = view.getBoundingClientRect();
+
+				if (!this.getAttribute('clone')) {
+					var clone = Polymer.dom(this).cloneNode(true);
+					clone.setAttribute('clone', 'true');
+					document.body.appendChild(clone);
+					setTimeout(function() {
+						var rect = clone.getBoundingClientRect();
+						this.style.height = rect.height + 'px';
+						document.body.removeChild(clone);
+					}.bind(this), 0);
+				}
+
 			}
-			this.style.height = rect.height + 'px';
+
 		},
 
 		__getActiveView: function() {

--- a/hierarchical-view-behavior.html
+++ b/hierarchical-view-behavior.html
@@ -161,16 +161,14 @@
 
 			} else {
 
-				if (!this.getAttribute('clone')) {
-					var clone = Polymer.dom(this).cloneNode(true);
-					clone.setAttribute('clone', 'true');
-					document.body.appendChild(clone);
-					setTimeout(function() {
-						var rect = clone.getBoundingClientRect();
-						this.style.height = rect.height + 'px';
-						document.body.removeChild(clone);
-					}.bind(this), 0);
-				}
+				var clone = Polymer.dom(this).cloneNode(true);
+				clone.setAttribute('clone', 'true');
+				document.body.appendChild(clone);
+				setTimeout(function() {
+					var rect = clone.getBoundingClientRect();
+					this.style.height = rect.height + 'px';
+					document.body.removeChild(clone);
+				}.bind(this), 0);
 
 			}
 


### PR DESCRIPTION
This change updates the auto sizing logic for hierarchical view: if the view is not displayed then it will be cloned to body and positioned offscreen where its height can be obtained.