### PR TITLE
Update so menu-item:initialize will always be called.

### DIFF
--- a/menu-item-behavior.html
+++ b/menu-item-behavior.html
@@ -46,21 +46,25 @@
 
 		ready: function() {
 			var children = this.getEffectiveChildren();
-			if (children && children.length > 0 && children[0].tagName !== 'TEMPLATE') {
-				this.__initialize();
+			if (children && children.length > 0 && children[0].tagName === 'TEMPLATE') {
+				return;
 			}
+			this.__initialize();
 		},
 
 		__initialize: function() {
 			var children = this.getEffectiveChildren();
-			if (children && children.length > 0) {
-				this.hasChildView = true;
-				this.__children = children;
-				this.setAttribute('aria-haspopup', true);
-				this.__children[0].setAttribute('label', this.text);
-				if (this._initialize) {
-					this._initialize();
+			for (var i=0; i<children.length; i++) {
+				if (children[i].tagName !== 'TEMPLATE') {
+					this.hasChildView = true;
+					this.__children = children;
+					this.setAttribute('aria-haspopup', true);
+					this.__children[0].setAttribute('label', this.text);
+					break;
 				}
+			}
+			if (this._initialize) {
+				this._initialize();
 			}
 		},
 

--- a/menu-item-behavior.html
+++ b/menu-item-behavior.html
@@ -54,7 +54,7 @@
 
 		__initialize: function() {
 			var children = this.getEffectiveChildren();
-			for (var i=0; i<children.length; i++) {
+			for (var i = 0; i < children.length; i++) {
 				if (children[i].tagName !== 'TEMPLATE') {
 					this.hasChildView = true;
 					this.__children = children;


### PR DESCRIPTION
@capajon : does this make sense?  The purpose here is to defer initialize until template is resolved, and to only set child-view specific properties if the item has at least one non-template child.  Initialize will be called regardless.