### PR TITLE
Adding no-auto-focus option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Optionally add the `no-auto-close` attribute to have the dropdown remain open wh
 </body>
 ```
 
+Optionally add the `no-auto-focus` attribute to disable auto-focus on first focusable descendant.
+
+```html
+<body>
+	...
+	<d2l-dropdown no-auto-focus target-id="my-opener" >
+		your content
+	</d2l-dropdown>
+</body>
+```
+
 Optionally hide the pointer by specifying the `no-pointer` attribute.
 
 ```html

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "d2l-colors": "~2.0.0",
     "d2l-hierarchical-view": "~0.0.6",
     "d2l-icons": "~2.1.0",
+    "d2l-polymer-behaviors": "~0.0.2",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
     "polymer": "^1.5.0"

--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -79,6 +79,7 @@
 
 			ready: function() {
 				this.noAutoFit = true;
+				this.noAutoFocus = true;
 				this.__container = this.$$('.d2l-dropdown-container');
 			},
 

--- a/d2l-dropdown.html
+++ b/d2l-dropdown.html
@@ -7,7 +7,7 @@
 	<template>
 		<style include="d2l-dropdown-styles"></style>
 
-		<div class="d2l-dropdown-container" tabindex="0">
+		<div class="d2l-dropdown-container">
 			<div class="d2l-dropdown-pointer">
 				<div></div>
 			</div>

--- a/dropdown-behavior.html
+++ b/dropdown-behavior.html
@@ -148,7 +148,7 @@
 				if (!this.noAutoFocus) {
 					var focusable = D2L.Dom.Focus.getFirstFocusableDescendant(this);
 					if (focusable) {
-							focusable.focus();
+						focusable.focus();
 					}
 				}
 

--- a/dropdown-behavior.html
+++ b/dropdown-behavior.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-dom-focus.html">
 <link rel="import" href="position-behavior.html">
 <script>
 (function() {
@@ -18,17 +19,20 @@
 			noAutoFit: {
 				type: Boolean
 			},
+			noAutoFocus: {
+				type: Boolean
+			},
 			opened: {
 				type: Boolean,
 				observer: '__openedChanged',
 				reflectToAttribute: true
 			},
 			openerId: String,
-			targetId: String,
 			horizontalOffset: {
 				type: Number,
 				value: 0
 			},
+			targetId: String,
 			verticalOffset: {
 				type: Number,
 				value: 20
@@ -141,8 +145,11 @@
 
 				this.__position();
 
-				if (this.__container.getAttribute('tabindex') === '0') {
-					this.__container.focus();
+				if (!this.noAutoFocus) {
+					var focusable = D2L.Dom.Focus.getFirstFocusableDescendant(this);
+					if (focusable) {
+							focusable.focus();
+					}
 				}
 
 				this.fire('open');

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -13,33 +13,34 @@
 
 		<test-fixture id="Dropdown">
 			<template>
-				<d2l-dropdown id="dropdown" target-id="opener">
-					<p>Lorem ipsum dolor sit...</p>
-					<a id="dropdownLink" href="http://www.google.com">Google 1</a>
-				</d2l-dropdown>
-				<a id="otherLink" href="http://www.google.com">Google 2</a>
+				<div>
+					<d2l-dropdown id="dropdown" target-id="opener">
+						<p>Lorem ipsum dolor sit...</p>
+						<a id="link_1" href="http://www.google.com">Google 1</a>
+						<a id="link_2" href="http://www.google.com">Google 1</a>
+					</d2l-dropdown>
+					<a id="other_link" href="http://www.google.com">Google 2</a>
+				</div>
 			</template>
 		</test-fixture>
 		<script>
 
 		describe('<d2l-dropdown>', function() {
 
-			var dropdown, dropdownLink, otherLink;
+			var dropdownFixture, dropdown;
 
 			beforeEach(function() {
-				fixture('Dropdown');
-				dropdown = document.getElementById('dropdown');
-				dropdownLink = document.getElementById('dropdownLink');
-				otherLink = document.getElementById('otherLink');
+				dropdownFixture = fixture('Dropdown');
+				dropdown = dropdownFixture.querySelector('#dropdown');
 			});
 
 			it('distributes its children', function() {
 				var content = dropdown.getContentChildren();
-				expect(content.length).to.equal(2);
+				expect(content.length).to.equal(3);
 				expect(content[0]).to.equal(dropdown.querySelector('p'));
 			});
 
-			it('should fire open event when open attribute is added', function(done) {
+			it('fires open event when open attribute is added', function(done) {
 				dropdown.addEventListener('open', function() {
 					expect(dropdown.opened).to.be.true;
 					done();
@@ -47,8 +48,7 @@
 				dropdown.setAttribute('opened', true);
 			});
 
-
-			it('should fire close event when open attribute is removed', function(done) {
+			it('fires close event when open attribute is removed', function(done) {
 				dropdown.addEventListener('open', function() {
 					dropdown.removeAttribute('opened');
 				});
@@ -59,10 +59,10 @@
 				dropdown.setAttribute('opened', true);
 			});
 
-			it('should close when focus lost and auto-close is specified', function(done) {
+			it('closes when focus lost and auto-close is specified', function(done) {
 				dropdown.addEventListener('open', function() {
-					dropdownLink.focus();
-					otherLink.focus();
+					dropdown.querySelector('#link_1').focus();
+						dropdownFixture.querySelector('#other_link').focus();
 				});
 				dropdown.addEventListener('close', function() {
 					expect(dropdown.opened).to.be.false;
@@ -71,16 +71,34 @@
 				dropdown.setAttribute('opened', true);
 			});
 
-			it('should not close when focus lost and auto-close is not specified', function(done) {
+			it('does not close when focus lost and auto-close is not specified', function(done) {
 				dropdown.addEventListener('open', function() {
-					dropdownLink.focus();
-					otherLink.focus();
+					dropdown.querySelector('#link_1').focus();
+					dropdownFixture.querySelector('#other_link').focus();
 					setTimeout(function() {
 						expect(dropdown.opened).to.be.true;
 						done();
 					},100);
 				});
 				dropdown.setAttribute('no-auto-close', true);
+				dropdown.setAttribute('opened', true);
+			});
+
+			it('focuses on descendant when opened', function(done) {
+				dropdown.addEventListener('open', function() {
+					expect(document.activeElement).to.equal(dropdown.querySelector('#link_1'));
+					done();
+				});
+				dropdown.setAttribute('opened', true);
+			});
+
+			it('does not focus on descendant when opened and no-auto-focus attribute is specified', function(done) {
+				var activeElement = document.activeElement;
+				dropdown.addEventListener('open', function() {
+					expect(document.activeElement).to.equal(activeElement);
+					done();
+				});
+				dropdown.setAttribute('no-auto-focus', true);
 				dropdown.setAttribute('opened', true);
 			});
 


### PR DESCRIPTION
If `no-auto-focus` attribute is applied the component will not automatically focus on first focusable descendant.  Useful for cases where the content of the dropdown may not be ready yet.  Default behavior is to automatically apply focus to the first focusable descendant.