### PR TITLE
Fix to show overflow ellipsis.  

### DIFF
--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -13,7 +13,7 @@
 				padding: 0;
 			}
 
-			:host a {
+			:host > a {
 				color: inherit;
 				display: block;
 				line-height: 1.2rem;

--- a/d2l-menu-item-link.html
+++ b/d2l-menu-item-link.html
@@ -16,8 +16,13 @@
 			:host a {
 				color: inherit;
 				display: block;
-				padding: 1rem;
+				line-height: 1.2rem;
+				outline: none;
+				overflow-x: hidden;
+				padding: 0.9rem 1rem;
 				text-decoration: none;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 		</style>

--- a/d2l-menu-item-return.html
+++ b/d2l-menu-item-return.html
@@ -11,15 +11,23 @@
 
 			:host {
 				display: flex;
+				padding: 0.9rem 1rem;
 			}
 
 			:host > span {
 				flex: auto;
+				line-height: 1.2rem;
+				overflow-x: hidden;
+				text-decoration: none;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			:host > iron-icon {
+				flex: none;
 				height: 18px;
 				margin-right: 1rem;
+				margin-top: 0.2rem;
 				width: 18px;
 			}
 

--- a/d2l-menu-item-styles.html
+++ b/d2l-menu-item-styles.html
@@ -10,12 +10,7 @@
 				box-sizing: border-box;
 				cursor: pointer;
 				display: block;
-				line-height: 1rem;
-				overflow-x: hidden;
 				outline: none;
-				padding: 1rem;
-				text-overflow: ellipsis;
-				white-space: nowrap;
 				width: 100%;
 			}
 

--- a/d2l-menu-item.html
+++ b/d2l-menu-item.html
@@ -12,14 +12,21 @@
 
 			:host {
 				display: flex;
+				padding: 0.9rem 1rem;
 			}
 
 			:host > span {
 				flex: auto;
+				line-height: 1.2rem;
+				overflow-x: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 
 			:host > iron-icon {
+				flex: none;
 				height: 18px;
+				margin-top: 0.2rem;
 				width: 18px;
 			}
 

--- a/demo/menu-custom-components.html
+++ b/demo/menu-custom-components.html
@@ -10,6 +10,13 @@
 		<style include="d2l-menu-item-styles">
 			:host {
 				display: block;
+				padding: 0.9rem 1rem;
+			}
+			:host span {
+				line-height: 1.2rem;
+				overflow-x: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 			}
 			:host(:hover) span,
 			:host(:focus) span {


### PR DESCRIPTION
This change updates the styles for `d2l-menu-item`, `d2l-menu-item-return`, and `d2l-menu-item-link` so that they display ellipsis when they overflow.  It was necessary to shift some padding to line-height so that the bottom of characters don't get cut off (ex. "g").
.