### PR TITLE
Initialize again if menu items change

### DIFF
--- a/d2l-menu-item-behavior.html
+++ b/d2l-menu-item-behavior.html
@@ -54,7 +54,7 @@
 			Polymer.dom(this).observeNodes(this.__initialize);
 		},
 
-		__initialize: function() {			
+		__initialize: function() {
 			var children = this.getEffectiveChildren();
 			if (children && children.length > 0 && children[0].tagName === 'TEMPLATE') {
 				return;

--- a/d2l-menu-item-behavior.html
+++ b/d2l-menu-item-behavior.html
@@ -50,15 +50,16 @@
 		__children: null,
 
 		ready: function() {
+			this.__initialize();
+			Polymer.dom(this).observeNodes(this.__initialize);
+		},
+
+		__initialize: function() {			
 			var children = this.getEffectiveChildren();
 			if (children && children.length > 0 && children[0].tagName === 'TEMPLATE') {
 				return;
 			}
-			this.__initialize();
-		},
 
-		__initialize: function() {
-			var children = this.getEffectiveChildren();
 			for (var i = 0; i < children.length; i++) {
 				if (children[i].tagName !== 'TEMPLATE') {
 					this.hasChildView = true;


### PR DESCRIPTION
@dbatiste This change does seem to solve the issue of creating the element and then appending to it after.

The compare is sure confusing looking - I recommend just looking at the updated ready and __initialize functions without comparison markings. :)

If this looks good I'll have to do a patch release.