### PR TITLE
Auto-Close Fixes

### DIFF
--- a/dropdown-behavior.html
+++ b/dropdown-behavior.html
@@ -46,18 +46,19 @@
 
 		ready: function() {
 			this.__onResize = this.__onResize.bind(this);
-			this.__onAutoClose = this.__onAutoClose.bind(this);
+			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
+			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
 		},
 
 		attached: function() {
-			document.body.addEventListener('focus', this.__onAutoClose, true);
-			document.body.addEventListener('click', this.__onAutoClose, true);
+			document.body.addEventListener('focus', this.__onAutoCloseFocus, true);
+			document.body.addEventListener('click', this.__onAutoCloseClick, true);
 			window.addEventListener('resize', this.__onResize);
 		},
 
 		detached: function() {
-			document.body.removeEventListener('focus', this.__onAutoClose, true);
-			document.body.removeEventListener('click', this.__onAutoClose, true);
+			document.body.removeEventListener('focus', this.__onAutoCloseFocus, true);
+			document.body.removeEventListener('click', this.__onAutoCloseClick, true);
 			window.removeEventListener('resize', this.__onResize);
 		},
 
@@ -73,22 +74,26 @@
 			this.opened = true;
 		},
 
-		__onAutoClose: function() {
-
-			if (!this.opened || this.noAutoClose) {
-				return;
-			}
-
+		__onAutoCloseFocus: function() {
 			setTimeout(function() {
-				if (!this.opened || !document.activeElement) {
-					return;
-				}
-				if (this.__isDeepChild(document.activeElement)) {
+				if (!this.opened
+					|| this.noAutoClose
+					|| !document.activeElement
+					|| document.activeElement === document.body
+					|| this.__isDeepChild(document.activeElement)) {
 					return;
 				}
 				this.opened = false;
 			}.bind(this), 0);
+		},
 
+		__onAutoCloseClick: function(evt) {
+			if (!this.opened
+				|| this.noAutoClose
+				|| this.__isDeepChild(Polymer.dom(evt).rootTarget)) {
+				return;
+			}
+			this.opened = false;
 		},
 
 		__onClose: function(e) {

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -6,9 +6,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
 		<link rel="import" href="../d2l-dropdown.html">
 	</head>
-	<body>
+	<body tabindex="-1">
 		<button id="opener">opener</button>
 
 		<test-fixture id="Dropdown">
@@ -16,10 +17,9 @@
 				<div>
 					<d2l-dropdown id="dropdown" target-id="opener">
 						<p>Lorem ipsum dolor sit...</p>
-						<a id="link_1" href="http://www.google.com">Google 1</a>
-						<a id="link_2" href="http://www.google.com">Google 1</a>
+						<button id="elem_inside">in here</button>
 					</d2l-dropdown>
-					<a id="other_link" href="http://www.google.com">Google 2</a>
+					<button id="elem_outside">out here</p>
 				</div>
 			</template>
 		</test-fixture>
@@ -36,7 +36,7 @@
 
 		describe('<d2l-dropdown>', function() {
 
-			describe('focusable content', function() {
+			describe('general', function() {
 
 				var dropdownFixture, dropdown;
 
@@ -47,71 +47,139 @@
 
 				it('distributes its children', function() {
 					var content = dropdown.getContentChildren();
-					expect(content.length).to.equal(3);
+					expect(content.length).to.equal(2);
 					expect(content[0]).to.equal(dropdown.querySelector('p'));
 				});
 
-				it('fires open event when open attribute is added', function(done) {
-					dropdown.addEventListener('open', function() {
-						expect(dropdown.opened).to.be.true;
-						done();
-					});
-					dropdown.setAttribute('opened', true);
-				});
+				describe('events', function() {
 
-				it('fires close event when open attribute is removed', function(done) {
-					dropdown.addEventListener('open', function() {
-						dropdown.removeAttribute('opened');
-					});
-					dropdown.addEventListener('close', function() {
-						expect(dropdown.opened).to.be.false;
-						done();
-					});
-					dropdown.setAttribute('opened', true);
-				});
-
-				it('closes when focus lost and auto-close is specified', function(done) {
-					dropdown.addEventListener('open', function() {
-						dropdown.querySelector('#link_1').focus();
-							dropdownFixture.querySelector('#other_link').focus();
-					});
-					dropdown.addEventListener('close', function() {
-						expect(dropdown.opened).to.be.false;
-						done();
-					});
-					dropdown.setAttribute('opened', true);
-				});
-
-				it('does not close when focus lost and auto-close is not specified', function(done) {
-					dropdown.addEventListener('open', function() {
-						dropdown.querySelector('#link_1').focus();
-						dropdownFixture.querySelector('#other_link').focus();
-						setTimeout(function() {
+					it('fires open event when open attribute is added', function(done) {
+						dropdown.addEventListener('open', function() {
 							expect(dropdown.opened).to.be.true;
 							done();
-						},100);
+						});
+						dropdown.setAttribute('opened', true);
 					});
-					dropdown.setAttribute('no-auto-close', true);
-					dropdown.setAttribute('opened', true);
+
+					it('fires close event when open attribute is removed', function(done) {
+						dropdown.addEventListener('open', function() {
+							dropdown.removeAttribute('opened');
+						});
+						dropdown.addEventListener('close', function() {
+							expect(dropdown.opened).to.be.false;
+							done();
+						});
+						dropdown.setAttribute('opened', true);
+					});
+
 				});
 
-				it('focuses on descendant when opened', function(done) {
-					dropdown.addEventListener('open', function() {
-						expect(dropdown.__container.getAttribute('tabindex')).to.be.null;
-						expect(document.activeElement).to.equal(dropdown.querySelector('#link_1'));
-						done();
+				describe('auto-focus', function() {
+
+					it('focuses on descendant when opened', function(done) {
+						dropdown.addEventListener('open', function() {
+							expect(dropdown.__container.getAttribute('tabindex')).to.be.null;
+							expect(document.activeElement).to.equal(dropdown.querySelector('#elem_inside'));
+							done();
+						});
+						dropdown.setAttribute('opened', true);
 					});
-					dropdown.setAttribute('opened', true);
+
+					it('does not focus on descendant when opened and no-auto-focus attribute is specified', function(done) {
+						var activeElement = document.activeElement;
+						dropdown.addEventListener('open', function() {
+							expect(document.activeElement).to.equal(activeElement);
+							done();
+						});
+						dropdown.setAttribute('no-auto-focus', true);
+						dropdown.setAttribute('opened', true);
+					});
+
 				});
 
-				it('does not focus on descendant when opened and no-auto-focus attribute is specified', function(done) {
-					var activeElement = document.activeElement;
-					dropdown.addEventListener('open', function() {
-						expect(document.activeElement).to.equal(activeElement);
-						done();
+				describe('auto-close', function() {
+
+					it('should close when focus element outside receives focus', function(done) {
+						dropdown.addEventListener('open', function() {
+							dropdownFixture.querySelector('#elem_outside').focus();
+						});
+						dropdown.addEventListener('close', function() {
+							expect(dropdown.opened).to.be.false;
+							done();
+						});
+						dropdown.setAttribute('opened', true);
 					});
-					dropdown.setAttribute('no-auto-focus', true);
-					dropdown.setAttribute('opened', true);
+
+					it('should not close when element outside receives focus and no-auto-close is set', function(done) {
+						dropdown.addEventListener('open', function() {
+							dropdownFixture.querySelector('#elem_outside').focus();
+							setTimeout(function() {
+								expect(dropdown.opened).to.be.true;
+								done();
+							},100);
+						});
+						dropdown.setAttribute('no-auto-close', true);
+						dropdown.setAttribute('opened', true);
+					});
+
+					it('should not close when element inside receives focus', function(done) {
+						dropdown.addEventListener('open', function() {
+							dropdown.querySelector('#elem_inside').focus();
+							setTimeout(function() {
+								expect(dropdown.opened).to.be.true;
+								done();
+							}, 100);
+						});
+						dropdown.setAttribute('opened', true);
+					});
+
+					it('should not close when activeElement becomes body', function(done) {
+						dropdown.addEventListener('open', function() {
+							// this simulates a click on an element inside the dropdown,
+							// which causes focus to be lost and activeElement to become
+							// document.body
+							document.body.focus();
+							setTimeout(function() {
+								expect(dropdown.opened).to.be.true;
+								done();
+							}, 100);
+						});
+						dropdown.setAttribute('opened', true);
+					});
+
+					it('should not close when element inside is clicked', function(done) {
+						dropdown.addEventListener('open', function() {
+							MockInteractions.tap(dropdown.querySelector('#elem_inside'));
+							setTimeout(function() {
+								expect(dropdown.opened).to.be.true;
+								done();
+							}, 100);
+						});
+						dropdown.setAttribute('opened', true);
+					});
+
+					it('should close when element outside is clicked', function(done) {
+						dropdown.addEventListener('open', function() {
+							MockInteractions.tap(dropdownFixture.querySelector('#elem_outside'));
+						});
+						dropdown.addEventListener('close', function() {
+							done();
+						});
+						dropdown.setAttribute('opened', true);
+					});
+
+					it('should not close when element outside is clicked and no-auto-close', function(done) {
+						dropdown.addEventListener('open', function() {
+							MockInteractions.tap(dropdownFixture.querySelector('#elem_outside'));
+							setTimeout(function() {
+								expect(dropdown.opened).to.be.true;
+								done();
+							}, 100);
+						});
+						dropdown.setAttribute('no-auto-close', true);
+						dropdown.setAttribute('opened', true);
+					});
+
 				});
 
 			});


### PR DESCRIPTION
@dbatiste 

This solves 2 issues:
- when a click occurs _inside_ the dropdown on an element which can't receive focus (e.g. the dropdown itself), `document.activeElement` becomes the `<body>` which caused the existing auto-focus code to close the dropdown
- the click handling code was using `document.activeElement` instead of the click target to check if it was a descendant