### PR TITLE
Move content-top and content-top to content-behavior

### DIFF
--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -209,6 +209,7 @@
 
 		listeners: {
 			'd2l-dropdown-close': '__onClose',
+			'd2l-dropdown-position': '__toggleScrollStyles',
 			'keyup': '__onKeyUp'
 		},
 
@@ -485,8 +486,6 @@
 				}
 
 				this.fire('d2l-dropdown-position');
-
-				this.__toggleScrollStyles();
 
 			}.bind(this);
 

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -103,6 +103,31 @@
 				padding: 0;
 			}
 
+			:host .d2l-dropdown-content-top,
+			:host .d2l-dropdown-content-bottom {
+				height: 10px;
+				position: relative;
+				z-index: 1;
+			}
+
+			:host .d2l-dropdown-content-top {
+				border-top-left-radius: 0.3rem;
+				border-top-right-radius: 0.3rem;
+			}
+
+			:host .d2l-dropdown-content-bottom {
+				border-bottom-left-radius: 0.3rem;
+				border-bottom-right-radius: 0.3rem;
+			}
+
+			:host .d2l-dropdown-content-top-scroll {
+				box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.05);
+			}
+
+			:host .d2l-dropdown-content-bottom-scroll {
+				box-shadow: 0 -3px 3px 0 rgba(0, 0, 0, 0.05);
+			}
+
 			:host-context([dir="rtl"]) {
 				left: auto;
 				right: 0;
@@ -187,24 +212,29 @@
 			'keyup': '__onKeyUp'
 		},
 
+		__content: null,
+
 		__isRTL: false,
 
 		ready: function() {
 			this.__onResize = this.__onResize.bind(this);
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
 			this.__onAutoCloseClick = this.__onAutoCloseClick.bind(this);
+			this.__content = this.$$('.d2l-dropdown-content-container');
 		},
 
 		attached: function() {
 			window.addEventListener('resize', this.__onResize);
 			document.body.addEventListener('focus', this.__onAutoCloseFocus, true);
 			document.body.addEventListener('click', this.__onAutoCloseClick, true);
+			this.listen(this.__content, 'scroll', '__toggleScrollStyles');
 		},
 
 		detached: function() {
 			window.removeEventListener('resize', this.__onResize);
 			document.body.removeEventListener('focus', this.__onAutoCloseFocus, true);
 			document.body.removeEventListener('click', this.__onAutoCloseClick, true);
+			this.unlisten(this.__content, 'scroll', '__toggleScrollStyles');
 		},
 
 		close: function() {
@@ -456,6 +486,8 @@
 
 				this.fire('d2l-dropdown-position');
 
+				this.__toggleScrollStyles();
+
 			}.bind(this);
 
 			/* don't let dropdown content horizontally overflow viewport */
@@ -473,6 +505,31 @@
 
 			adjustPosition();
 
+		},
+
+		__toggleScrollStyles: function() {
+			var topCap = this.$$('.d2l-dropdown-content-top');
+			var bottomCap = this.$$('.d2l-dropdown-content-bottom');
+			if (this.__content.scrollTop === 0) {
+				if (topCap.classList.contains('d2l-dropdown-content-top-scroll')) {
+					topCap.classList.remove('d2l-dropdown-content-top-scroll');
+				}
+			} else {
+				if (!topCap.classList.contains('d2l-dropdown-content-top-scroll')) {
+					topCap.classList.add('d2l-dropdown-content-top-scroll');
+				}
+			}
+
+			/* scrollHeight incorrect in IE by 4px second time opened */
+			if (this.__content.scrollHeight - (this.__content.scrollTop + this.__content.clientHeight) < 5) {
+				if (bottomCap.classList.contains('d2l-dropdown-content-bottom-scroll')) {
+					bottomCap.classList.remove('d2l-dropdown-content-bottom-scroll');
+				}
+			} else {
+				if (!bottomCap.classList.contains('d2l-dropdown-content-bottom-scroll')) {
+					bottomCap.classList.add('d2l-dropdown-content-bottom-scroll');
+				}
+			}
 		}
 
 	};

--- a/d2l-dropdown-content.html
+++ b/d2l-dropdown-content.html
@@ -7,9 +7,11 @@
 		<style include="d2l-dropdown-content-styles"></style>
 		<div class="d2l-dropdown-content-position">
 			<div class="d2l-dropdown-content-width">
+				<div class="d2l-dropdown-content-top"></div>
 				<div class="d2l-dropdown-content-container">
 					<content></content>
 				</div>
+				<div class="d2l-dropdown-content-bottom"></div>
 			</div>
 		</div>
 		<div class="d2l-dropdown-content-pointer">

--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -6,38 +6,11 @@
 <dom-module id="d2l-dropdown-menu">
 
 	<template>
-		<style include="d2l-colors d2l-dropdown-content-styles">
-
-			:host .d2l-dropdown-content-top,
-			:host .d2l-dropdown-content-bottom {
-				height: 10px;
-				position: relative;
-				z-index: 1;
-			}
-
-			:host .d2l-dropdown-content-top {
-				border-top-left-radius: 0.3rem;
-				border-top-right-radius: 0.3rem;
-			}
-
-			:host .d2l-dropdown-content-bottom {
-				border-bottom-left-radius: 0.3rem;
-				border-bottom-right-radius: 0.3rem;
-			}
-
-			:host .d2l-dropdown-content-top-scroll {
-				box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.05);
-			}
-
-			:host .d2l-dropdown-content-bottom-scroll {
-				box-shadow: 0 -3px 3px 0 rgba(0, 0, 0, 0.05);
-			}
-
-		</style>
+		<style include="d2l-colors d2l-dropdown-content-styles"></style>
 		<div class="d2l-dropdown-content-position">
 			<div class="d2l-dropdown-content-width">
 				<div class="d2l-dropdown-content-top"></div>
-				<div on-scroll="_onScroll" class="d2l-dropdown-content-container">
+				<div class="d2l-dropdown-content-container">
 					<content></content>
 				</div>
 				<div class="d2l-dropdown-content-bottom"></div>
@@ -59,17 +32,13 @@
 			listeners: {
 				'd2l-dropdown-close': '_onClose',
 				'd2l-dropdown-open': '_onOpen',
-				'd2l-dropdown-position': '_onPosition',
 				'd2l-menu-resize': '_onMenuResize',
 				'select': '_onSelect'
 			},
 
-			_content: null,
-
 			ready: function() {
 				this.noAutoFocus = true;
 				this.noPadding = true;
-				this._content = this.$$('.d2l-dropdown-content-container');
 			},
 
 			_onClose: function(e) {
@@ -108,44 +77,11 @@
 
 			},
 
-			_onPosition: function() {
-				this._toggleScrollStyles();
-			},
-
-			_onScroll: function() {
-				this._toggleScrollStyles();
-			},
-
 			_onSelect: function(e) {
 				if (e.target.tagName !== 'D2L-MENU-ITEM') {
 					return;
 				}
 				this.close();
-			},
-
-			_toggleScrollStyles: function() {
-				var topCap = this.$$('.d2l-dropdown-content-top');
-				var bottomCap = this.$$('.d2l-dropdown-content-bottom');
-				if (this._content.scrollTop === 0) {
-					if (topCap.classList.contains('d2l-dropdown-content-top-scroll')) {
-						topCap.classList.remove('d2l-dropdown-content-top-scroll');
-					}
-				} else {
-					if (!topCap.classList.contains('d2l-dropdown-content-top-scroll')) {
-						topCap.classList.add('d2l-dropdown-content-top-scroll');
-					}
-				}
-
-				/* scrollHeight incorrect in IE by 4px second time opened */
-				if (this._content.scrollHeight - (this._content.scrollTop + this._content.clientHeight) < 5) {
-					if (bottomCap.classList.contains('d2l-dropdown-content-bottom-scroll')) {
-						bottomCap.classList.remove('d2l-dropdown-content-bottom-scroll');
-					}
-				} else {
-					if (!bottomCap.classList.contains('d2l-dropdown-content-bottom-scroll')) {
-						bottomCap.classList.add('d2l-dropdown-content-bottom-scroll');
-					}
-				}
 			}
 
 		});

--- a/d2l-dropdown-menu.html
+++ b/d2l-dropdown-menu.html
@@ -1,12 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-menu/d2l-menu.html">
 <link rel="import" href="d2l-dropdown-content-behavior.html">
 
 <dom-module id="d2l-dropdown-menu">
 
 	<template>
-		<style include="d2l-colors d2l-dropdown-content-styles"></style>
+		<style include="d2l-dropdown-content-styles"></style>
 		<div class="d2l-dropdown-content-position">
 			<div class="d2l-dropdown-content-width">
 				<div class="d2l-dropdown-content-top"></div>


### PR DESCRIPTION
These can be kind of nice to have on general content as well, if the content is scrollable. Moving them out of the d2l-dropdown-menu and into the underlying behavior so that they're available in all cases.

Fixes #76.

Is this worth being able to turn on/off with an attribute? It's fairly innocuous, but idk, might be circumstances where we explicitly don't want it?