### PR TITLE
Fix case where dropdown closes when clicked if it has focusable ancestor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "d2l-icons": "^2.9.6",
     "d2l-menu": "~0.0.7",
     "d2l-offscreen": "~2.1.0",
-    "d2l-polymer-behaviors": "~0.0.3",
+    "d2l-polymer-behaviors": "~0.0.4",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
     "polymer": "^1.5.0"

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -299,7 +299,7 @@
 					|| this.noAutoClose
 					|| !document.activeElement
 					|| document.activeElement === this.__previousFocusableAncestor
-					|| document.body) {
+					|| document.activeElement === document.body) {
 					return;
 				}
 

--- a/d2l-dropdown-content-behavior.html
+++ b/d2l-dropdown-content-behavior.html
@@ -217,6 +217,8 @@
 
 		__isRTL: false,
 
+		__previousFocusableAncestor: null,
+
 		ready: function() {
 			this.__onResize = this.__onResize.bind(this);
 			this.__onAutoCloseFocus = this.__onAutoCloseFocus.bind(this);
@@ -296,7 +298,8 @@
 				if (!this.opened
 					|| this.noAutoClose
 					|| !document.activeElement
-					|| document.activeElement === document.body) {
+					|| document.activeElement === this.__previousFocusableAncestor
+					|| document.body) {
 					return;
 				}
 
@@ -356,6 +359,11 @@
 		},
 
 		__openedChanged: function(newValue) {
+
+			this.__previousFocusableAncestor =
+				newValue === true
+					? D2L.Dom.Focus.getPreviousFocusableAncestor(this, false, false)
+					: null;
 
 			this.__isRTL = (getComputedStyle(this).direction === 'rtl');
 

--- a/test/dropdown-content.html
+++ b/test/dropdown-content.html
@@ -14,16 +14,18 @@
 
 		<test-fixture id="Dropdown">
 			<template>
-				<div id="optionallyFocusable">
-					<d2l-dropdown>
-						<button class="d2l-dropdown-opener"></button>
-						<d2l-dropdown-content>
-							<p id="non_focusable_inside"></p>
-							<a id="focusable_inside" href="http://www.desire2learn.com"></a>
-						</d2l-dropdown-content>
-					</d2l-dropdown>
-					<p id="non_focusable_outside"></p>
-					<button id="focusable_outside">out here</button>
+				<div>
+					<div id="optionallyFocusable">
+						<d2l-dropdown>
+							<button class="d2l-dropdown-opener"></button>
+							<d2l-dropdown-content>
+								<p id="non_focusable_inside"></p>
+								<a id="focusable_inside" href="http://www.desire2learn.com"></a>
+							</d2l-dropdown-content>
+						</d2l-dropdown>
+						<p id="non_focusable_outside"></p>
+						<button id="focusable_outside">out here</button>
+					</div>
 				</div>
 			</template>
 		</test-fixture>

--- a/test/dropdown-content.html
+++ b/test/dropdown-content.html
@@ -14,7 +14,7 @@
 
 		<test-fixture id="Dropdown">
 			<template>
-				<div>
+				<div id="optionallyFocusable">
 					<d2l-dropdown>
 						<button class="d2l-dropdown-opener"></button>
 						<d2l-dropdown-content>
@@ -203,6 +203,23 @@
 						// which causes focus to be lost and activeElement to become
 						// document.body
 						document.body.focus();
+						setTimeout(function() {
+							expect(content.opened).to.be.true;
+							done();
+						}, 100);
+					});
+					content.setAttribute('opened', true);
+				});
+
+				it('should not close when activeElement becomes focusable ancestor', function(done) {
+					var focusableAncestor = dropdownFixture.querySelector('#optionallyFocusable');
+					focusableAncestor.setAttribute('tabindex', '-1');
+
+					content.addEventListener('d2l-dropdown-open', function() {
+						// this simulates a click on an element inside the dropdown,
+						// which causes focus to be lost and activeElement to become
+						// the focusable ancestor of the dropdown
+						focusableAncestor.focus();
 						setTimeout(function() {
 							expect(content.opened).to.be.true;
 							done();


### PR DESCRIPTION
When a dropdown has an ancestor that's focusable, that ancestor may (in all cases I've observed, will) gain focus when an empty area of a dropdown is clicked. This adds an additional check in the focus handler that the focused element isn't a focused ancestor, so that autoclose is deferred to the click handler instead as in other cases.